### PR TITLE
[Fix] #70 긴글자 읽기 관련 이슈 해결

### DIFF
--- a/Oculo/TextReaderViewController.swift
+++ b/Oculo/TextReaderViewController.swift
@@ -20,10 +20,14 @@ func speak(_ string: String) {
     utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
 
     /// synthesizer에서 현재 말하는 중인 경우 즉시 중단한다. (소리가 겹쳐서 들리는 현상 방지)
+    stopSpeak()
+    synthesizer.speak(utterance)
+}
+
+func stopSpeak() {
     if (synthesizer.isSpeaking) {
         synthesizer.stopSpeaking(at: AVSpeechBoundary.immediate)
     }
-    synthesizer.speak(utterance)
 }
 
 class TextReaderViewController: UIViewController, ImageAnalysisInteractionDelegate, UIGestureRecognizerDelegate {
@@ -58,7 +62,7 @@ class TextReaderViewController: UIViewController, ImageAnalysisInteractionDelega
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-
+        stopSpeak()
         arView.session.pause()
     }
 


### PR DESCRIPTION
### Motivation
- Text Reader에서 장문의 Text를 읽을 때, 기능 종료시에도 Text를 계속 읽는 이슈가 있습니다.
- 재현 방법: 긴 글을 읽게한 뒤 스크롤을 내려 뷰를 종료해도 계속 텍스트를 읽습니다.

### Key Changes
- View를 종료하면 글자 읽기를 멈춥니다.
- TTS를 멈추는 stopSpeak라는 Function을 별도로 생성하였습니다.

### To Reviewers
- TextReaderViewController에 있는 TTS 기능을 따로 다른 파일에 빼야할 것 같습니다.
