### PR TITLE
[Fix] #71 화면 회전시 UI 깨짐 현상

### DIFF
--- a/Oculo/AppDelegate.swift
+++ b/Oculo/AppDelegate.swift
@@ -68,5 +68,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
+    /// 강제 세로 화면 설정
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return .portrait
+    }
 }
 


### PR DESCRIPTION
### Motivation
- 버그 재생 조건: 화면 회전시 UI가 깨지고, 다시 원래 화면으로 돌아와도 UI가 복구되지 않음

### Key Changes
- AppDelegate.swift 내 화면 강제 portrait 모드 코드 추가

### To Reviewers
- 가로 모드에서도 깨지지 않도록 손볼 필요가 있을 것 같습니다. 나중에 이슈 등록하고 해결해 보아용!