### PR TITLE
[Refactor] #78 Deprecated 함수 변경

### DIFF
--- a/Oculo/EnvironmentReader/Plane.swift
+++ b/Oculo/EnvironmentReader/Plane.swift
@@ -35,7 +35,7 @@ class Plane: SCNNode {
         meshNode = SCNNode(geometry: meshGeometry)
         
         // Create a node to visualize the plane's bounding rectangle.
-        let extentPlane: SCNPlane = SCNPlane(width: CGFloat(anchor.extent.x), height: CGFloat(anchor.extent.z))
+        let extentPlane: SCNPlane = SCNPlane(width: CGFloat(anchor.planeExtent.width), height: CGFloat(anchor.planeExtent.height))
         extentNode = SCNNode(geometry: extentPlane)
         extentNode.simdPosition = anchor.center
         
@@ -105,7 +105,7 @@ class Plane: SCNNode {
 
         let textNode = SCNNode(geometry: textGeometry)
         // scale down the size of the text
-        textNode.simdScale = float3(0.0005)
+        textNode.simdScale = SIMD3<Float>(repeating: 0.0005)
         
         return textNode
     }

--- a/Oculo/EnvironmentReader/Utilities.swift
+++ b/Oculo/EnvironmentReader/Utilities.swift
@@ -25,16 +25,16 @@ extension ARPlaneAnchor.Classification {
 extension SCNNode {
     func centerAlign() {
         let (min, max) = boundingBox
-        let extents = float3(max) - float3(min)
-        simdPivot = float4x4(translation: ((extents / 2) + float3(min)))
+        let extents = SIMD3<Float>(max) - SIMD3<Float>(min)
+        simdPivot = float4x4(translation: ((extents / 2) + SIMD3<Float>(min)))
     }
 }
 
 extension float4x4 {
-    init(translation vector: float3) {
-        self.init(float4(1, 0, 0, 0),
-                  float4(0, 1, 0, 0),
-                  float4(0, 0, 1, 0),
-                  float4(vector.x, vector.y, vector.z, 1))
+    init(translation vector: SIMD3<Float>) {
+        self.init(SIMD4<Float>(1, 0, 0, 0),
+                  SIMD4<Float>(0, 1, 0, 0),
+                  SIMD4<Float>(0, 0, 1, 0),
+                  SIMD4<Float>(vector.x, vector.y, vector.z, 1))
     }
 }


### PR DESCRIPTION
### Motivation
- Environment Reader의 샘플 코드가 iOS 12.0 기반으로 만들어져 있어서 iOS16에서 Deprecated 된 기능을 사용하는 부분이 존재합니다.
- 유지보수의 편의를 위해 해당 기능을 대체하였습니다.

### Key Changes
- iOS 16에서 Deprecated 된 함수 변경 float3 -> SIMD3<Float>
float4 -> SIMD4<Float>
extent.x -> planeExtent.width
extent.y -> planeExtent.height
init(_:) -> init(repeating:)

### To Reviewers
- 
