### PR TITLE
[Feat] #55 #74 Custom Rotor 구현

### DIFF
--- a/Oculo/MainViewController.swift
+++ b/Oculo/MainViewController.swift
@@ -20,6 +20,9 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     var bufferSize: CGSize = .zero
     var rootLayer: CALayer! = nil
 
+    // Varibale for Custom Rotor
+    var rotorPropertyValueLabel: UILabel!
+    
 //    @IBOutlet weak private var previewView: UIView!  // MARK: Storyboard component
     private var previewView: UIView!
     
@@ -51,6 +54,9 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         self.view.addSubview(self.createEnvironmentReaderButton)
         self.view.addSubview(self.createTextReadingButton)
         self.view.addSubview(self.createSettingButton)
+        
+        let buttonRotor = self.switchingButtonRotor()
+        self.accessibilityCustomRotors = [buttonRotor]
     }
 
     lazy var createNavigateButton: UIButton = {
@@ -179,6 +185,29 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
 //
 //        return UIToggleSwitch
 //    }()
+    
+    // MARK: Switching Button Custom Rotor
+    private func switchingButtonRotor() -> UIAccessibilityCustomRotor {
+        
+        // Create a custor Rotor option, it has a name that will be read by voice over, and
+        // a action that is a action called when this rotor option is interacted with.
+        // The predicate gives you info about the state of this interaction
+        let propertyRotorOption = UIAccessibilityCustomRotor.init(name: "버튼 변경") { (predicate) -> UIAccessibilityCustomRotorItemResult? in
+            
+            // Get the direction of the movement when this rotor option is enablade
+            // 버튼 변경에 대한 로직이 들어가야합니다.
+    // let forward = predicate.searchDirection == UIAccessibilityCustomRotor.Direction.next
+            
+            // You can do any kind of business logic processing here
+            
+            
+            // Return the selection of voice over to the element rotorPropertyValueLabel
+            // Use this return to select the desired selection that fills the purpose of its logic
+            return UIAccessibilityCustomRotorItemResult.init(targetElement: self.rotorPropertyValueLabel , targetRange: nil)
+        }
+        
+        return propertyRotorOption
+    }
 
     @objc func onClickSwitch(sender: UISwitch) {
 //        var text: String!  // MARK: Marked as an annotation for possible later use -> Swiping UI


### PR DESCRIPTION
### Motivation
- 볼륨버튼/락버튼 과 같은 물리버튼은 애플의 정책상 커스텀할 수 없습니다.
- 더 나은 사용자의 UX를 위해, 로터를 커스텀했습니다.

### Key Changes
- 보이스오버 활성화시, 로터에 "버튼 변경"이라는 요소가 들어가도록 만들었습니다.
- 버튼 변경 활성화시, 스와이핑을 통해 모드를 바꿀 수 있습니다.

### To Reviewers
- #74 에 대한 이슈도 같이 해결되었습니다.
- 로터의 내장 기능에 보이스오버 속도 조절 기능이 있습니다.
