### PR TITLE
[Fix] #108 SoundManager블루투스이어폰 연결 또는 끊김시 발생하는 오류해결, 구조개선

### DIFF
--- a/Oculo/SoundManager.swift
+++ b/Oculo/SoundManager.swift
@@ -13,53 +13,46 @@ class SoundManager {
     /// 출처  https://stackoverflow.com/questions/66145794/avaudioengine-positional-audio-not-working-with-playandrecord-audio-session-cat
 
     let audioEngine = AVAudioEngine()  /// 오디오 엔진 선언
-    let defaultBeep = "defalutBeep.mp3"  /// 출처 https://www.soundjay.com/censor-beep-sound-effect.html
-    let audioPlayerNode = AVAudioPlayerNode()
+    let defaultBeep = "defaultBeep.mp3"  /// 출처 https://www.soundjay.com/censor-beep-sound-effect.html
+    let audioPlayerNode = AVAudioPlayerNode() /// 오디오 플레어어 노드 선언
     let environmentNode = AVAudioEnvironmentNode()  /// 오디오 환경 노드 선언
+    ///대략적인 오디오 엔진 구조 : AVAudioEnvironmentNode -> AVAudioPlayerNode -> 재생 의 과정을 거친다. 여기선 AVAudioEnvironmentNode노드는 사용자의 위치를, AVAudioPlayerNode는 플레이어의 위치를 설정한다고 생각하면 편하다
+    
     init() {
+        // MARK: AVAudioSession 설정
         /// 오디오 세션 선언 (앱에서 오디오를 사용하는 방식을 시스템에 전잘하는 객체), 여기서는 공유된 오디오 세션 인스턴스로 설정
         let audioSession = AVAudioSession.sharedInstance()
-
         /// 소리 재생 모드. 블루투스 기기와의 연결을 허용하는 오디오 세션 설정
-        try! audioSession.setCategory(.playAndRecord, mode: .default, options: .allowBluetoothA2DP)
-
-        /**
-         Using .playback the positional audio DOES work, however we are not able to record.
-         */
-        // try! audioSession.setCategory(.playback)
-
+        try! audioSession.setCategory(.playAndRecord, mode: .default, options: [.allowBluetoothA2DP,.defaultToSpeaker])
+        try! audioSession.setActive(true)
+        
+        // MARK: AVAudioEnvironmentNode 설정
         self.environmentNode.listenerPosition = AVAudio3DPoint(x: 0, y: 0, z: 0)  /// 사용자의 위치를 0,0,0 으로 지정
         self.audioEngine.attach(self.environmentNode)  /// AvAudioEngine 에 environmentNode 연결
         let stereoFormat = AVAudioFormat(standardFormatWithSampleRate: self.audioEngine.outputNode.outputFormat(forBus: 0).sampleRate, channels: 2)  /// 2채널 스테레오 포맷 생성
-
         /// environmentNode 을 outputNode에 연결
         self.audioEngine.connect(self.environmentNode, to: self.audioEngine.outputNode, format: stereoFormat)
-
         /// AVAudioEngine 준비상태로 설정
         self.audioEngine.prepare()
-
         /// AVAudioEigine 시작
         try! self.audioEngine.start()
+        
+        // MARK: AVAudioPlayerNode 설정
+        /// audioPlayerNode을 audioEngine에 붙힘
+        self.audioEngine.attach(self.audioPlayerNode)
+        /// 1 채널 모노 포맷 생성 (Spatial Audio 를 위해서는 재생음원이 1채널 이어야만 함)
+        let monoFormat =  AVAudioFormat(standardFormatWithSampleRate: self.audioEngine.outputNode.outputFormat(forBus: 0).sampleRate, channels: 1)
+        /// 위에서 생성한 environmentNode에 audioPlayerNode 연결
+        self.audioEngine.connect(self.audioPlayerNode, to: self.environmentNode, format: monoFormat)
+        self.audioPlayerNode.renderingAlgorithm = .HRTFHQ  /// 가상으로 3dPositioning하는 알고리즘 설정
     }
 
     // TODO: 블루투스 재생 뿐 아니라 스피커로 재생하는 방법 필요
     func play(x:Float, y:Float, z:Float, TTS:String = "defaultBeep.mp3") {
-
-        /// audioPlayerNode을 audioEngine에 붙힘
-        self.audioEngine.attach(self.audioPlayerNode)
-
-        /// 1 채널 모노 포맷 생성 (Spatial Audio 를 위해서는 재생음원이 1채널 이어야만 함)/
-        let monoFormat =  AVAudioFormat(standardFormatWithSampleRate: self.audioEngine.outputNode.outputFormat(forBus: 0).sampleRate, channels: 1)
-
-        /// 위에서 생성한 environmentNode에 audioPlayerNode 연결
-        self.audioEngine.connect(self.audioPlayerNode, to: self.environmentNode, format: monoFormat)
-
-        // TODO: defaultBeep.mp3 이 아닐 경우 TTS로 읽어주는 기능 작성 필요
-        let url = Bundle.main.url(forResource: TTS, withExtension: nil)  /// defaultBeep의 URL
-        let f = try! AVAudioFile(forReading: url!)  /// defaultBeep 의 음원 파일을 읽어 와서
-
-        self.audioPlayerNode.scheduleFile(f, at: nil, completionHandler: nil)  /// audioPlayerNode에 등록
-        self.audioPlayerNode.renderingAlgorithm = .HRTFHQ  /// 가상으로 3dPositioning하는 알고리즘 설정
+        let defaultBeepUrl = Bundle.main.url(forResource: self.defaultBeep, withExtension: nil)  /// defaultBeep의 URL
+        let defaultBeepFile = try! AVAudioFile(forReading: defaultBeepUrl!)  /// defaultBeep 의 음원 파일을 읽어 와서
+        self.audioPlayerNode.scheduleFile(defaultBeepFile, at: nil, completionHandler: nil)  /// audioPlayerNode에 등록
+        
         self.audioPlayerNode.position = AVAudio3DPoint(x: x, y: y, z: z)  /// 소리가 나는 위치 포지셔닝
         self.audioPlayerNode.play()  /// 음원 재생 시작
     }


### PR DESCRIPTION
### Motivation
-SoundManager 객체 생성후 블루투스 이어폰이 연결되거나 끊길시 앱이 비정상적으로 종료되는 문제가 발생했습니다.
-SoundManager 클래스의 Play 메서드가 콜 될때마다 불필요하게 반복적으로 AVAudioPlayerNode를 설정하는 부분이있어 init() 메서드에서 한번에 설정할수 있도록 구조를 개선했습니다.

### Key Changes
-AVAudioSession 에서 카테고리에 allowBluetoothA2DP 와 defaultToSpeaker 옵션을 모두주어 블루투스 연결에 관계없이 상황에 따라 소리를 재생할수있도록 설정하였습니다.
-AVAudioPlayerNode 의 모노포맷 설정, AVAudioEnvironmentNode 에 연결하는 부분, AVAudioPlayerNode의 렌더링 알고리즘 설정 부분이 불필요하게 Play 메소드에서 반복되는거같아 init 메서드에서 설정하도록 변경하였습니다.
-defaultBeep String 에 오타가 있어 수정했습니다.

### To Reviewers
-간단한 옵션추가, 구조의 개선이있었습니다 자세한 내용은 Key Changes 참조 부탁드립니다.
