### PR TITLE
[Feat] HealthKitManager 연동, TTS 적용

### DIFF
--- a/Oculo/EnvironmentReader/Plane.swift
+++ b/Oculo/EnvironmentReader/Plane.swift
@@ -53,8 +53,9 @@ class Plane: SCNNode {
         addChildNode(extentNode)
         
         // Display the plane's distance from camera
-        let distance = String(simd_distance(meshNode.simdTransform.columns.3, (sceneView.session.currentFrame?.camera.transform.columns.3)!))
-        let textNode = self.makeTextNode(distance)
+        let distance = simd_distance(meshNode.simdTransform.columns.3, (sceneView.session.currentFrame?.camera.transform.columns.3)!)
+        let steps = String(healthKitManager.calToStepCount(meter: Double(distance)))
+        let textNode = self.makeTextNode(steps)
         distanceNode = textNode
         // Change the pivot of the text node to its center
         textNode.centerAlign()

--- a/Oculo/HealthkitManager.swift
+++ b/Oculo/HealthkitManager.swift
@@ -199,3 +199,6 @@ class HealthKitManager {
 //        healthStore.execute(query)
 //    }
 }
+
+// HealthKitManager를 다양한 곳에서 사용하기 때문에 전역 변수로 따로 빼두었습니다.
+var healthKitManager = HealthKitManager()

--- a/Oculo/MainViewController.swift
+++ b/Oculo/MainViewController.swift
@@ -35,6 +35,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         super.viewWillAppear(animated)
         // set
         UIDevice.current.isProximityMonitoringEnabled = true
+        // 처음 앱을 작동시켰을때 healthKit Manager에서 사용자의 보폭 정보를 불러오기 위한 시험 코드입니다.
+        print(healthKitManager.calToStepCount(meter: 10))
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
### Motivation
- 현재 적용되어 있는 meter단위의 거리를 보폭단위로 변환할 필요가 있습니다.
- TTS를 적용하여 효과적으로 안내해야합니다.

### Key Changes
- HealthKit에서 보폭 정보를 읽어와 거리를 보폭으로 변환합니다.
- 보폭에 변동이 있을경우 TTS로 안내합니다.
- AR Exception 관련 안내 멘트 일부 수정하였습니다.
- HealthKitManager를 전역 변수로 따로 빼두었습니다. -> healthKitManager
- healthKitManager는 MainViewController 실행시 자동으로 초기화하고, 정보를 읽어옵니다.

### To Reviewers
- 더 나아질 수 있는 방법은 iOS에서 기본 제공하는 확대기 등을 사용하며 알아보겠습니다.
