### PR TITLE
[Refactor] Environment Reader 관련 View 배치 함수 정리, 오타 수정

### DIFF
--- a/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
+++ b/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
@@ -28,25 +28,8 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
         self.view.addSubview(sceneView)
         self.view.addSubview(initializeButton)
         
-        sceneView.translatesAutoresizingMaskIntoConstraints = false
-        
-        sceneView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
-        sceneView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
-        sceneView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
-        sceneView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-        
-        initializeButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        initializeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
-        initializeButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
-        initializeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
-        initializeButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-        
-        initializeButton.addTarget(self, action: #selector(resetTrackingByButton), for: .touchUpInside)
-        
-        sceneView.subviews.forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        }
+        createInitializeButton()
+        addConstraints()
         
         sceneView.delegate = self
     }
@@ -161,16 +144,16 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
 
     func session(_ session: ARSession, didAdd anchors: [ARAnchor]) {
         guard let frame = session.currentFrame else { return }
-        updateSessionInfoLabel(for: frame, trackingState: frame.camera.trackingState)
+        updateSessionInfoAndSpeak(for: frame, trackingState: frame.camera.trackingState)
     }
 
     func session(_ session: ARSession, didRemove anchors: [ARAnchor]) {
         guard let frame = session.currentFrame else { return }
-        updateSessionInfoLabel(for: frame, trackingState: frame.camera.trackingState)
+        updateSessionInfoAndSpeak(for: frame, trackingState: frame.camera.trackingState)
     }
 
     func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
-        updateSessionInfoLabel(for: session.currentFrame!, trackingState: camera.trackingState)
+        updateSessionInfoAndSpeak(for: session.currentFrame!, trackingState: camera.trackingState)
     }
 
     // MARK: - ARSessionObserver
@@ -214,7 +197,7 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
 
     // MARK: - Private methods
 
-    private func updateSessionInfoLabel(for frame: ARFrame, trackingState: ARCamera.TrackingState) {
+    private func updateSessionInfoAndSpeak(for frame: ARFrame, trackingState: ARCamera.TrackingState) {
         // Update the UI to provide feedback on the state of the AR experience.
         let message: String
 
@@ -245,7 +228,7 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
             soundManager.speak(message)
         }
     }
-
+/*
     private func resetTracking() {
         let configuration = ARWorldTrackingConfiguration()
         configuration.planeDetection = [.vertical]
@@ -253,8 +236,35 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
         self.anchors.removeAll()
         self.sceneView.session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
     }
+ */
     
-    @objc func resetTrackingByButton() {
+    func createInitializeButton() {
+        initializeButton.addTarget(self, action: #selector(resetTracking), for: .touchUpInside)
+        initializeButton.setTitle("문 인식 초기화", for: .normal)
+        initializeButton.setTitle("", for: .selected)
+    }
+    
+    func addConstraints() {
+        
+        sceneView.translatesAutoresizingMaskIntoConstraints = false
+        initializeButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        sceneView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        sceneView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        sceneView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        sceneView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        
+        initializeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        initializeButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        initializeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        initializeButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        
+        sceneView.subviews.forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+    
+    @objc private func resetTracking() {
         let configuration = ARWorldTrackingConfiguration()
         configuration.planeDetection = [.vertical]
         self.planes.removeAll()

--- a/Oculo/TextReaderViewController.swift
+++ b/Oculo/TextReaderViewController.swift
@@ -43,7 +43,7 @@ class TextReaderViewController: UIViewController, ImageAnalysisInteractionDelega
 
     /// hideView의 배경색 지정
     func createTextReadButton() {
-        textReadButton.backgroundColor = .blue
+        textReadButton.setTitle("글자 인식", for: .normal)
         textReadButton.addTarget(self, action: #selector(analyzeCurrentImageAndSpeak), for: .touchUpInside)
     }
 

--- a/Oculo/Utilities/ko.lproj/Localizable.strings
+++ b/Oculo/Utilities/ko.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 // Main View
 "Navigation" = "내비게이션";
 "Environment Reader" = "주변 환경 읽기";
-"Text Reader" = "긁자 읽기";
+"Text Reader" = "글자 읽기";
 "Settings" = "설정";
 
 // Setting View


### PR DESCRIPTION
### Motivation
- Environment detection과 관련된 페이지가 기존 예제 코드에 요소를 추가하는 방식이다보니 정리가 되지 않았습니다.
- 기타 이름과 오타 수정이 필요합니다.

### Key Changes
- View를 배치하는 과정을 함수로 분리하였습니다.
- 같은 기능을 사용하는 함수를 하나로 통일하였습니다.
- 오타를 수정하였습니다. (긁자-> 글자)
- Environment Recognition, TextReader의 버튼에 제목을 추가하였습니다. (VoiceOver 사용성 개선)

### To Reviewers
- 깃 사용에 약간의 이슈가 발생하여 주석 등은 추후 정리할 예정입니다.
