### PR TITLE
[Feat] 문 인식에 대한 안내 멘트 추가 및 변경

### DIFF
--- a/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
+++ b/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
@@ -140,8 +140,8 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
         if let distanceNode = plane.distanceNode,
            let distanceGeometry = distanceNode.geometry as? SCNText {
             let currentDistance = simd_distance(node.simdTransform.columns.3, (sceneView.session.currentFrame?.camera.transform.columns.3)!)
-            let currentSteps = healthKitManager.calToStepCount(meter: Double(currentDistance))
-            // print(currentDistance)
+            var currentSteps = healthKitManager.calToStepCount(meter: Double(currentDistance))
+            if (currentSteps > 10) { currentSteps = 10 }
             if let oldSteps = distanceGeometry.string as? String, oldSteps != String(currentSteps) {
                 distanceGeometry.string = String(currentSteps)
                 
@@ -153,8 +153,26 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
                         {
                         case 0:
                             soundManager.speak("근처에 문이 있습니다")
+                        case 1:
+                            soundManager.speak("문으로 부터 약 한 걸음 떨어져 있습니다")
+                        case 2:
+                            soundManager.speak("문으로 부터 약 두 걸음 떨어져 있습니다")
+                        case 3:
+                            soundManager.speak("문으로 부터 약 세 걸음 떨어져 있습니다")
+                        case 4:
+                            soundManager.speak("문으로 부터 약 네 걸음 떨어져 있습니다")
+                        case 5:
+                            soundManager.speak("문으로 부터 약 다섯 걸음 떨어져 있습니다")
+                        case 6:
+                            soundManager.speak("문으로 부터 약 여섯 걸음 떨어져 있습니다")
+                        case 7:
+                            soundManager.speak("문으로 부터 약 일곱 걸음 떨어져 있습니다")
+                        case 8:
+                            soundManager.speak("문으로 부터 약 여덟 걸음 떨어져 있습니다")
+                        case 9:
+                            soundManager.speak("문으로 부터 약 아홉 걸음 떨어져 있습니다")
                         default:
-                            soundManager.speak("문으로 부터 약 \(currentSteps) 걸음 떨어져 있습니다")
+                            soundManager.speak("문으로 부터 멀리 떨어져 있습니다. 화면을 눌러 인식을 초기화 해주세요")
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation
- 문과 잘못된 방향으로 가고 있는 경우, 이를 피드백을 할 별도 Action이 필요합니다. #124 
- 걸음수를 안내할때 한자가 아닌 고유어로 유저에게 피드백을 받자는 제안이 왔습니다. #118 

### Key Changes
- 문이 감지되지 않는 경우, TTS를 통해 문의 방향을 안내하는 기능을 추가하였습니다.
- 걸음수를 일 걸음 이 걸음으로 표현하던 방식에서 한 걸음 두 걸음으로 문맥에 맍게 변경하였습니다.
- AR의 정확한 plane detection distance와 같은 스펙은 알 수 없지만 개인적으로 측정한 결과, 5 걸음 부터 문 인식을 수행했습니다. 그래서 최대 9걸음으로 잡고 10걸음 부터는 사용법에 대한 안내 멘트가 출력됩니다.

### To Reviewers
- 더 좋은 방법이 있다면 적극 반영하도록 하겠습니다.
