### PR TITLE
[Fix] #128 버튼 제목 제거

### DIFF
--- a/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
+++ b/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
@@ -295,6 +295,7 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
     func createInitializeButton() {
         initializeButton.addTarget(self, action: #selector(resetTracking), for: .touchUpInside)
         initializeButton.setTitle("문 인식 초기화", for: .normal)
+        initializeButton.setTitle("", for: .selected)
     }
     
     func addConstraints() {

--- a/Oculo/TextReaderViewController.swift
+++ b/Oculo/TextReaderViewController.swift
@@ -49,6 +49,7 @@ class TextReaderViewController: UIViewController, ImageAnalysisInteractionDelega
     /// hideView의 배경색 지정
     func createTextReadButton() {
         textReadButton.setTitle("글자 인식", for: .normal)
+        textReadButton.setTitle("", for: .selected)
         textReadButton.addTarget(self, action: #selector(analyzeCurrentImageAndSpeak), for: .touchUpInside)
     }
 


### PR DESCRIPTION
### Motivation
- 버튼의 내용을 읽는 것과 안내 멘트 충돌을 줄여야 합니다. #128 

### Key Changes
- 버튼을 선택한 경우, 버튼의 제목을 제거하여 TTS와의 충돌 방지 (테스트 완료)

### To Reviewers
-
