### PR TITLE
Fix/synthesizer playback problem

### DIFF
--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -12,7 +12,7 @@ import ARKit
 import SceneKit
 
 class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNViewDelegate {
-    var soundManger = SoundManager()
+    var soundManager = SoundManager()
     var healthKitManager = HealthKitManager()
     let maxWidth:Double = 191.0
     let maxHeight = 255.0
@@ -226,7 +226,7 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
             minValueDictionary[minDepth] = [minDepthCoordinate, String(prediction.label!)]  /// depth 최솟값을 좌표:깊이 쌍으로 딕셔너리에 추가
         }
 
-        if !minValueDictionary.isEmpty && !soundManger.synthesizer.isSpeaking {
+        if !minValueDictionary.isEmpty && !soundManager.synthesizer.isSpeaking {
 
             let sorted = minValueDictionary.keys.sorted()
             let firstKey = sorted[0]
@@ -256,9 +256,35 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
                 coordinatorString += "하단"
             }
                     
-            let steps = healthKitManager.calToStepCount(meter: Double(firstKey))
-            let TTS = "\(coordinatorString)에 \(firstItem![1])가 \(steps)걸음 떨어져 있습니다"
-            soundManger.speak(TTS)
+            var steps = healthKitManager.calToStepCount(meter: Double(firstKey))
+            var stepsString = ""
+            switch steps
+            {
+            case 0:
+                stepsString = "근처에 있습니다"
+            case 1:
+                stepsString = "약 한 걸음 떨어져 있습니다"
+            case 2:
+                stepsString = "약 두 걸음 떨어져 있습니다"
+            case 3:
+                stepsString = "약 세 걸음 떨어져 있습니다"
+            case 4:
+                stepsString = "약 네 걸음 떨어져 있습니다"
+            case 5:
+                stepsString = "약 다섯 걸음 떨어져 있습니다"
+            case 6:
+                stepsString = "약 여섯 걸음 떨어져 있습니다"
+            case 7:
+                stepsString = "약 일곱 걸음 떨어져 있습니다"
+            case 8:
+                stepsString = "약 여덟 걸음 떨어져 있습니다"
+            case 9:
+                stepsString = "약 아홉 걸음 떨어져 있습니다"
+            default:
+                stepsString = "멀리 떨어져 있습니다."
+            }
+            let TTS = "\(coordinatorString)에 \(firstItem![1])가 "+stepsString
+            soundManager.speak(TTS)
             print(TTS)
             
         }

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -285,7 +285,7 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
             default:
                 stepsString = "멀리 떨어져 있습니다."
             }
-            let TTS = "\(coordinatorString)에 \(firstItem![1])가 "+stepsString
+            let TTS = "\(coordinatorString)에 \(firstItem![1])가 " + stepsString
             soundManager.speak(TTS)
             print(TTS)
             

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -13,6 +13,7 @@ import SceneKit
 
 class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNViewDelegate {
     var soundManger = SoundManager()
+    var healthKitManager = HealthKitManager()
     // MARK: UI 프로퍼티
     lazy var videoPreview: ARSCNView = {
         let videoPreview = ARSCNView(frame: self.view.frame)

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -14,8 +14,8 @@ import SceneKit
 class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNViewDelegate {
     var soundManager = SoundManager()
     var healthKitManager = HealthKitManager()
-    let maxWidth:Double = 191.0
-    let maxHeight:Double = 255.0
+    let maxWidth: Double = 191.0
+    let maxHeight: Double = 255.0
     // MARK: UI 프로퍼티
     lazy var videoPreview: ARSCNView = {
         let videoPreview = ARSCNView(frame: self.view.frame)

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -15,7 +15,7 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
     var soundManager = SoundManager()
     var healthKitManager = HealthKitManager()
     let maxWidth:Double = 191.0
-    let maxHeight = 255.0
+    let maxHeight:Double = 255.0
     // MARK: UI 프로퍼티
     lazy var videoPreview: ARSCNView = {
         let videoPreview = ARSCNView(frame: self.view.frame)

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -251,7 +251,9 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
             if yRatio < 33 {
                 coordinatorString += "상단"
             } else if xRatio < 67 {
-                coordinatorString += "중단"
+                if !(coordinatorString == "정면") {
+                    coordinatorString += "가운데"
+                }
             } else {
                 coordinatorString += "하단"
             }

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -250,7 +250,7 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
             
             if yRatio < 33 {
                 coordinatorString += "상단"
-            } else if xRatio < 67 {
+            } else if yRatio < 67 {
                 if !(coordinatorString == "정면") {
                     coordinatorString += "가운데"
                 }

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -14,6 +14,8 @@ import SceneKit
 class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNViewDelegate {
     var soundManger = SoundManager()
     var healthKitManager = HealthKitManager()
+    let maxWidth:Double = 191.0
+    let maxHeight = 255.0
     // MARK: UI 프로퍼티
     lazy var videoPreview: ARSCNView = {
         let videoPreview = ARSCNView(frame: self.view.frame)
@@ -225,9 +227,37 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
         }
 
         if !minValueDictionary.isEmpty && !soundManger.synthesizer.isSpeaking {
-            var sorted = minValueDictionary.keys.sorted()
-            var firstItem = minValueDictionary[sorted[0]]
-            var TTS = "\(firstItem![0])에 \(firstItem![1])있습니다"
+
+            let sorted = minValueDictionary.keys.sorted()
+            let firstKey = sorted[0]
+            let firstItem = minValueDictionary[firstKey]
+            let splited = firstItem![0].split(separator: ", ")
+            
+            let y = Int(String(splited[0]))!
+            let x = Int(String(splited[1]))!
+            
+            let xRatio = Int((Double(x) / maxWidth * 100.0 ))
+            let yRatio = Int((Double(y) / maxHeight * 100.0 ))
+            
+            var coordinatorString = ""
+            if xRatio < 33 {
+                coordinatorString += "좌측"
+            } else if xRatio < 67 {
+                coordinatorString += "정면"
+            } else {
+                coordinatorString += "우측"
+            }
+            
+            if yRatio < 33 {
+                coordinatorString += "상단"
+            } else if xRatio < 67 {
+                coordinatorString += "중단"
+            } else {
+                coordinatorString += "하단"
+            }
+                    
+            let steps = healthKitManager.calToStepCount(meter: Double(firstKey))
+            let TTS = "\(coordinatorString)에 \(firstItem![1])가 \(steps)걸음 떨어져 있습니다"
             soundManger.speak(TTS)
             print(TTS)
             

--- a/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
+++ b/Oculo/ObjectRecognizer/ObjectDetectionViewController.swift
@@ -241,11 +241,11 @@ class ObjectDetectionViewController: UIViewController, ARSessionDelegate, ARSCNV
             
             var coordinatorString = ""
             if xRatio < 33 {
-                coordinatorString += "좌측"
+                coordinatorString += "우측"
             } else if xRatio < 67 {
                 coordinatorString += "정면"
             } else {
-                coordinatorString += "우측"
+                coordinatorString += "좌측"
             }
             
             if yRatio < 33 {

--- a/Oculo/Utilities/SoundManager.swift
+++ b/Oculo/Utilities/SoundManager.swift
@@ -78,7 +78,7 @@ class SoundManager {
             utterance.volume = speakingVolume
 
             /// synthesizer에서 현재 말하는 중인 경우 즉시 중단한다. (소리가 겹쳐서 들리는 현상 방지)
-            stopSpeak()
+            synthesizer.stopSpeaking(at: AVSpeechBoundary.word)
             synthesizer.speak(utterance)
         }
     }


### PR DESCRIPTION
### Motivation
- 가장 가까이있는 물체의 좌표를 9분할해 위치에 따라 안내해주기 위함입니다.

### Key Changes
- soundManager의 stopSpeak메서드의 if (synthesizer.isSpeaking) 분기가 정확하지않아 stopSpeak 메서드의 사용을 중지하고 synthesizer가 기존에 말하던게 끝나면 중단하는것으로 변경하였습니다.
- 가장 가까이있는 물체와의 거리를 받아 걸음수로 변경후, 화면을 9분할 한뒤 좌표와 라벨을 TTS로 읽어주게 변경하였습니다.

### To Reviewers
- 제 나름대로 화이트 박스테스트와 블랙박스테스트를 해보았으나 이상이 발견되지않아 PR올립니다. 리뷰어분들께서도 테스트 부탁드립니다.
