### PR TITLE
Design/Main Button Color

### DIFF
--- a/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
+++ b/Oculo/EnvironmentReader/EnvironmentReaderViewController.swift
@@ -299,7 +299,7 @@ class EnvironmentReaderViewController: UIViewController, ARSCNViewDelegate, ARSe
 
     func createInitializeButton() {
         initializeButton.addTarget(self, action: #selector(resetTracking), for: .touchUpInside)
-        initializeButton.setTitle("문 인식 초기화", for: .normal)
+        initializeButton.setTitle(Language(rawValue: "Reset door recognition")?.localized, for: .normal)
         initializeButton.setTitle("", for: .selected)
     }
 

--- a/Oculo/MainViewController.swift
+++ b/Oculo/MainViewController.swift
@@ -92,6 +92,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
         environmentReaderButton.setTitle(Language(rawValue: "Environment Reader")?.localized, for: .normal)
         environmentReaderButton.titleLabel?.font = .systemFont(ofSize: fontSize, weight: .bold)
         environmentReaderButton.titleLabel?.lineBreakMode = .byWordWrapping
+        environmentReaderButton.titleLabel?.textAlignment = .center
         environmentReaderButton.layer.cornerRadius = 10.0
         environmentReaderButton.tag = 2
         environmentReaderButton.addTarget(self, action: #selector(onTouchButton), for: .touchUpInside)

--- a/Oculo/MainViewController.swift
+++ b/Oculo/MainViewController.swift
@@ -24,7 +24,8 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     lazy var environmentReaderButton = UIButton()
     lazy var textReaderButton = UIButton()
     lazy var settingButton = UIButton()
-
+    var fontSize: CGFloat = 60
+    
     /// Variable for object detection camera view
     var bufferSize: CGSize = .zero
     var rootLayer: CALayer! = nil
@@ -77,34 +78,38 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     func createNavigateButton() {
         navigationButton.backgroundColor = UIColor.black
         navigationButton.setTitle(Language(rawValue: "Navigation")?.localized, for: .normal)
+        navigationButton.titleLabel?.font = .systemFont(ofSize: fontSize, weight: .bold)
         navigationButton.layer.cornerRadius = 10.0
         navigationButton.tag = 1
         navigationButton.addTarget(self, action: #selector(onTouchButton), for: .touchUpInside)
         navigationButton.layer.cornerRadius = 10.0
         navigationButton.layer.borderWidth = 10
-        navigationButton.layer.borderColor = UIColor.red.cgColor
+        navigationButton.layer.borderColor = UIColor.white.cgColor
     }
 
     func createEnvironmentReaderButton() {
         environmentReaderButton.backgroundColor = UIColor.black
         environmentReaderButton.setTitle(Language(rawValue: "Environment Reader")?.localized, for: .normal)
+        environmentReaderButton.titleLabel?.font = .systemFont(ofSize: fontSize, weight: .bold)
+        environmentReaderButton.titleLabel?.lineBreakMode = .byWordWrapping
         environmentReaderButton.layer.cornerRadius = 10.0
         environmentReaderButton.tag = 2
         environmentReaderButton.addTarget(self, action: #selector(onTouchButton), for: .touchUpInside)
         environmentReaderButton.layer.cornerRadius = 10.0
         environmentReaderButton.layer.borderWidth = 10
-        environmentReaderButton.layer.borderColor = UIColor.yellow.cgColor
+        environmentReaderButton.layer.borderColor = UIColor.white.cgColor
     }
 
     func createTextReaderButton() {
         textReaderButton.backgroundColor = UIColor.black
         textReaderButton.setTitle(Language(rawValue: "Text Reader")?.localized, for: .normal)
+        textReaderButton.titleLabel?.font = .systemFont(ofSize: fontSize, weight: .bold)
         textReaderButton.layer.cornerRadius = 10.0
         textReaderButton.tag = 3
         textReaderButton.addTarget(self, action: #selector(onTouchButton), for: .touchUpInside)
         textReaderButton.layer.cornerRadius = 10.0
         textReaderButton.layer.borderWidth = 10
-        textReaderButton.layer.borderColor = UIColor.blue.cgColor
+        textReaderButton.layer.borderColor = UIColor.white.cgColor
     }
 
     func createSettingButton() {
@@ -226,19 +231,28 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     @objc func onTouchButton(_ sender: UIButton) {
         self.selected = sender.tag
         if(selected == 1) {
-            self.navigationButton.backgroundColor = .red
+            self.navigationButton.setTitleColor(.black, for: .normal)
+            self.environmentReaderButton.setTitleColor(.white, for: .normal)
+            self.textReaderButton.setTitleColor(.white, for: .normal)
+            self.navigationButton.backgroundColor = .white
             self.environmentReaderButton.backgroundColor = .black
             self.textReaderButton.backgroundColor = .black
             present(ObjectDetectionViewController(), animated: true)
         } else if (self.selected == 2) {
+            self.navigationButton.setTitleColor(.white, for: .normal)
+            self.environmentReaderButton.setTitleColor(.black, for: .normal)
+            self.textReaderButton.setTitleColor(.white, for: .normal)
             self.navigationButton.backgroundColor = .black
-            self.environmentReaderButton.backgroundColor = .yellow
+            self.environmentReaderButton.backgroundColor = .white
             self.textReaderButton.backgroundColor = .black
             present(EnvironmentReaderViewController(), animated: true)
         } else if (self.selected == 3) {
+            self.navigationButton.setTitleColor(.white, for: .normal)
+            self.environmentReaderButton.setTitleColor(.white, for: .normal)
+            self.textReaderButton.setTitleColor(.black, for: .normal)
             self.navigationButton.backgroundColor = .black
             self.environmentReaderButton.backgroundColor = .black
-            self.textReaderButton.backgroundColor = .blue
+            self.textReaderButton.backgroundColor = .white
             present(TextReaderViewController(), animated: true)
         }
     }

--- a/Oculo/TextReaderViewController.swift
+++ b/Oculo/TextReaderViewController.swift
@@ -48,7 +48,7 @@ class TextReaderViewController: UIViewController, ImageAnalysisInteractionDelega
 
     /// hideView의 배경색 지정
     func createTextReadButton() {
-        textReadButton.setTitle("글자 인식", for: .normal)
+        textReadButton.setTitle(Language(rawValue: "Text recognition")?.localized, for: .normal)
         textReadButton.setTitle("", for: .selected)
         textReadButton.addTarget(self, action: #selector(analyzeCurrentImageAndSpeak), for: .touchUpInside)
     }

--- a/Oculo/Utilities/StringExtension.swift
+++ b/Oculo/Utilities/StringExtension.swift
@@ -37,6 +37,10 @@ enum Language: String, Localizable {
     case privacy = "Privacy"
     case license = "License"
     case contactUS = "Contact Us"
+    
+    // Contorller
+    case doorRecognition = "Reset door recognition"
+    case textRecognition = "Text recognition"
 }
 
 let localizingDictionaryEngKor: [String: String] = [

--- a/Oculo/Utilities/en.lproj/Localizable.strings
+++ b/Oculo/Utilities/en.lproj/Localizable.strings
@@ -23,6 +23,6 @@
 "Contact Us" = "Contact Us";
 
 // Button Text
-"문 인식 초기화" = "Reset door recognition";
-"글자 인식" = "Text recognition";
+"Reset door recognition" = "Reset door recognition";
+"Text recognition" = "Text recognition";
 "메인 화면으로" = "Go to home screen";

--- a/Oculo/Utilities/ko.lproj/Localizable.strings
+++ b/Oculo/Utilities/ko.lproj/Localizable.strings
@@ -23,6 +23,6 @@
 "Contact Us" = "고객센터";
 
 // Button Text
-"문 인식 초기화" = "문 인식 초기화";
-"글자 인식" = "글자 인식";
+"Reset door recognition" = "문 인식 초기화";
+"Text recognition" = "글자 인식";
 "메인 화면으로" = "메인 화면으로";


### PR DESCRIPTION
### Motivation
- 저희 앱의 사용자는 채도보다 명도의 대비를 통해 구분을 더 쉽게 할 수 있기 때문에, 현재 Main 버튼의 색상 (빨강, 노랑, 파랑 같은 경우 명도보다 채도가 강조됨)보다 검흰 으로 대비를 주자는 의견이 나왔습니다.
- 주변환경 인식, 글자 읽기 기능을 선택할 시 로컬라이징 처리가 되지 않는 버그를 수정해야합니다.

### Key Changes
- MainButton의 폰트 크기를 수정하였습니다.
- MainButton의 색상(빨, 노, 파)을 흰색으로 변경하였습니다.  
- 적용되지 않은 로컬라이징을 적용시켰습니다.
### To Reviewers
- 코드 리뷰 환영합니다!
