### PR TITLE
[Feat] LiDAR 없는 휴대폰의 기능사용 불가 알림 #142

### DIFF
--- a/Oculo/MainViewController.swift
+++ b/Oculo/MainViewController.swift
@@ -267,7 +267,7 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     }
 
     func showAlert() {
-        let alert = UIAlertController(title: translate("알림"), message: translate("이 기기는 해당 기능을 지원하지 않습니다"), preferredStyle: .alert)
+        let alert = UIAlertController(title: translate("알림"), message: translate("이 기기는 LiDAR 센서가 없어, 해당 기능을 사용 할 수 없습니다"), preferredStyle: .alert)
         let okAction = UIAlertAction(title: translate("확인"), style: .default)
 
         alert.addAction(okAction)

--- a/Oculo/MainViewController.swift
+++ b/Oculo/MainViewController.swift
@@ -10,8 +10,10 @@ import UIKit
 import Foundation
 import AVFoundation
 import Vision
+import ARKit
 
 public let languageSetting = Locale.current.language.languageCode!.identifier
+let supportLiDAR = ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh)
 
 class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDelegate {
     var healthKitManager = HealthKitManager()
@@ -223,6 +225,11 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     @objc func onTouchButton(_ sender: UIButton) {
         self.selected = sender.tag
         if(selected == 1) {
+            guard supportLiDAR else {
+                showAlert()
+                return
+            }
+
             self.navigationButton.setTitleColor(.black, for: .normal)
             self.environmentReaderButton.setTitleColor(.white, for: .normal)
             self.textReaderButton.setTitleColor(.white, for: .normal)
@@ -231,6 +238,11 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
             self.textReaderButton.backgroundColor = .black
             present(ObjectDetectionViewController(), animated: true)
         } else if (self.selected == 2) {
+            guard supportLiDAR else {
+                showAlert()
+                return
+            }
+
             self.navigationButton.setTitleColor(.white, for: .normal)
             self.environmentReaderButton.setTitleColor(.black, for: .normal)
             self.textReaderButton.setTitleColor(.white, for: .normal)
@@ -252,6 +264,13 @@ class MainViewController: UIViewController, AVCaptureVideoDataOutputSampleBuffer
     @objc func openSettingView() {
         let mainVC = SettingViewController()
         present(mainVC, animated: true, completion: nil)
+    }
+
+    func showAlert() {
+        let alert = UIAlertController(title: translate("알림"), message: translate("이 기기는 해당 기능을 지원하지 않습니다"), preferredStyle: .alert)
+        let okAction = UIAlertAction(title: translate("확인"), style: .default)
+
+        alert.addAction(okAction)
     }
 }
 

--- a/Oculo/Utilities/StringExtension.swift
+++ b/Oculo/Utilities/StringExtension.swift
@@ -173,6 +173,11 @@ let localizingDictionaryKorEng: [String: String] = [
     " 상단": " top",
     " 가운데": " center",
     " 하단": " bottom",
+
+    ///LaidarSensorAlert
+    "알림": "Alert",
+    "확인": "Understood",
+    "이 기기는 해당 기능을 지원하지 않습니다": "The device doesn't support this function"
 ]
 
 let labelsIndefiniteArticleDictionary: [String:String] = [

--- a/Oculo/Utilities/StringExtension.swift
+++ b/Oculo/Utilities/StringExtension.swift
@@ -177,7 +177,7 @@ let localizingDictionaryKorEng: [String: String] = [
     ///LaidarSensorAlert
     "알림": "Alert",
     "확인": "Understood",
-    "이 기기는 해당 기능을 지원하지 않습니다": "The device doesn't support this function"
+    "이 기기는 LiDAR 센서가 없어, 해당 기능을 사용 할 수 없습니다": "The device doesn't support this function for lack of LiDAR sensor"
 ]
 
 let labelsIndefiniteArticleDictionary: [String:String] = [


### PR DESCRIPTION
### Motivation
- LiDAR를 사용할 수 없는 휴대폰들이 많아서 해당 기능이 없는 휴대폰이 ObjectDetection 같은 기능을 이용하고자 할 때 알림을 줄 필요가 있음

### Key Changes
- 내비게이션, 주변환경 버튼 클릭시 LiDAR 센서가 없는 휴대폰에 대해 기능사용 불가 알림

### To Reviewers
- 문구 수정 예정
